### PR TITLE
Fix dynamic_prefix() not doing recursively

### DIFF
--- a/dash_extensions/enrich.py
+++ b/dash_extensions/enrich.py
@@ -927,7 +927,7 @@ def dynamic_prefix(app: Union[DashBlueprint, DashProxy], component: Component):
     if len(prefix_transforms) == 0:
         return
     prefix_transform: PrefixIdTransform = prefix_transforms[0]
-    prefix_component(prefix_transform.prefix, component, prefix_transform.escape)
+    prefix_recursively(component, prefix_transform.prefix, prefix_transform.prefix_func, prefix_transform.escape)
 
 
 # endregion


### PR DESCRIPTION
The function dynamic_prefix() was applying prefix only in the first element. The expected behavior was to do it recursively. The dog.